### PR TITLE
Introduce dev versus main branches.

### DIFF
--- a/guidelines/pull_requests.md
+++ b/guidelines/pull_requests.md
@@ -1,5 +1,12 @@
 # Creating Pull Requests
 
+Please note that all branches for features and bug fixes should be
+against the `dev` branch and not the `main` branch. They should then
+be PRs back into `dev` rather than into `main`. 
+
+For reference see
+https://nvie.com/posts/a-successful-git-branching-model/
+
 ## 1. Ensure corresponding issue is open
 
 Every pull request should have a corresponding issue. If there is no
@@ -19,8 +26,8 @@ aware of this and are prepared to spend more time reviewing it.
 ## 3. Ensure pull request is up to date
 
 Before creating a pull request, ensure that your branch is up to date
-with the latest changes from the `main` branch. This can be done by
-running `git pull origin main` on your branch.
+with the latest changes from the `dev` branch. This can be done by
+running `git pull origin dev` on your branch.
 
 ## 4. Ensure the code meets style guidelines
 
@@ -29,8 +36,8 @@ that you can find in `support/flutter.mk` individually.
 
 ## 5. Pull request title
 
-The title of a pull request should be short and descriptive. .  This
-will be helpful if we move to sqaush and merge in the future.
+The title of a pull request should be short and descriptive.  This
+will be helpful if we move to squash and merge in the future.
 
 ## 6. Pull request description
 
@@ -48,16 +55,19 @@ request description and corresponding issue should be created. This
 will ensure that they are not forgotten.
 
 ## 8. Tests
+
 Every pull request should include tests. More information on testing
-can be found in `guidelines/test_guide.md`.
+can be found in `guidelines/test_guide.md`. Testing must meet a 90%
+coverage threshold
 
 # Reviewing Pull Requests
 
 ## 1. Ensure pull request is up to date
 
 Before reviewing a pull request, ensure that your branch is up to date
-with the latest changes from the `main` branch. This can be done by
-running `git pull origin main` on your branch.
+with the latest changes from the `dev` branch. This can be done by
+running `git pull origin dev` on the branch being reviewed for
+merging.
 
 ## 2. Review pull request
 


### PR DESCRIPTION
Note I am merging into gjw/add_launch_support rather than main to avoid the url launch updates from getting merged within this PR. Keep the PR to just one thing.