### PR TITLE
Propose we use local path to solid for dev.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
     sdk: flutter
 
   solid:
-    path: ../solid
+    path: solid
     # git:
     #   url: https://github.com/anusii/solid
     #   ref: main


### PR DESCRIPTION
I wonder if `path ../solid` works for everyone for the dev version of this repo. That way we can all be working on our own local solid repos while it is under development.  The `main` branch retains the git link to main branch.