### PR TITLE
Av/28 initial gui for viewing data

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,7 @@
 library;
 
 import 'package:flutter/material.dart';
+import 'package:keypod/screens/home.dart';
 
 import 'package:solidpod/solid.dart';
 import 'package:window_manager/window_manager.dart';
@@ -118,7 +119,11 @@ class KeyPod extends StatelessWidget {
         logo: AssetImage('assets/images/keypod_logo.png'),
         link: 'https://github.com/anusii/keypod',
         required: false,
-        child: Scaffold(body: Text('Key Pod Placeholder')),
+        child: Home(
+          // webId: '',
+          // authData: {},
+          appName: 'KeyPod',
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -120,8 +120,6 @@ class KeyPod extends StatelessWidget {
         link: 'https://github.com/anusii/keypod',
         required: false,
         child: Home(
-          // webId: '',
-          // authData: {},
           appName: 'KeyPod',
         ),
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,7 @@ library;
 import 'package:flutter/material.dart';
 import 'package:keypod/screens/home.dart';
 
-import 'package:solidpod/solid.dart';
+import 'package:solidpod/solidpod.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'package:keypod/utils/is_desktop.dart';

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -33,8 +33,9 @@ library;
 import 'package:flutter/material.dart';
 
 import 'package:intl/intl.dart';
-
 import 'package:solidpod/solid.dart';
+
+import 'package:keypod/screens/view_keys.dart';
 
 /// Widget represents the home screen of the application.
 ///
@@ -113,26 +114,55 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
                     ElevatedButton(
                       child: const Text('Show private data'),
                       onPressed: () async {
-                        final loggedIn = await checkLoggedIn();
+                        const filePath = 'encryption/enc-keys.ttl';
+                        final fileContent = await readPod(
+                            filePath,
+                            context,
+                            const Home(
+                              appName: 'KeyPod',
+                            ));
 
-                        if (loggedIn) {
-                          await Navigator.pushReplacement(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => ShowKeys(
-                                      appName: widget.appName,
-                                      child: Home(appName: widget.appName),
-                                    )),
-                          );
-                        } else {
-                          await Navigator.pushReplacement(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => PopupLogin(
+                        await Navigator.pushReplacement(
+                          context,
+                          MaterialPageRoute(
+                              builder: (context) => ViewKeys(
                                     appName: widget.appName,
-                                    child: Home(appName: widget.appName))),
-                          );
+                                    keyInfo: fileContent,
+                                  )),
+                        );
+                      },
+                    ),
+                    const SizedBox(
+                      height: 10,
+                    ),
+                    ElevatedButton(
+                      child: const Text('delete login data'),
+                      onPressed: () async {
+                        final deleteRes = await deleteLogIn();
+
+                        var deleteMsg = '';
+
+                        if (deleteRes) {
+                          deleteMsg = 'Successfully deleted login info';
+                        } else {
+                          deleteMsg =
+                              'Failed to delete login info. Try again in a while';
                         }
+
+                        await showDialog(
+                          context: context,
+                          builder: (context) => AlertDialog(
+                            title: const Text('Notice'),
+                            content: Text(deleteMsg),
+                            actions: [
+                              ElevatedButton(
+                                  onPressed: () {
+                                    Navigator.pop(context);
+                                  },
+                                  child: const Text('OK'))
+                            ],
+                          ),
+                        );
                       },
                     ),
                     const SizedBox(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -136,7 +136,7 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
                       height: 10,
                     ),
                     ElevatedButton(
-                      child: const Text('delete login data'),
+                      child: const Text('Delete login data'),
                       onPressed: () async {
                         final deleteRes = await deleteLogIn();
 

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -38,21 +38,14 @@ import 'package:solidpod/solid.dart';
 
 /// Widget represents the home screen of the application.
 ///
-/// It requires [webId] and [authData] to be passed to it during initialization.
-/// These parameters are used for authentication and data retrieval.
+/// It only requires [appName] to be passed to it during initialization.
+/// This is because this page is designed to be work in offline as well.
 
 class Home extends StatefulWidget {
   /// Initialise widget variables
 
-  const Home(
-      {
-      //required this.webId,
-      //required this.authData,
-      required this.appName,
-      super.key});
-  //final String webId;
+  const Home({required this.appName, super.key});
   final String appName;
-  //final Map<dynamic, dynamic> authData;
 
   @override
   HomeState createState() => HomeState();
@@ -120,12 +113,30 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
                     ElevatedButton(
                       child: const Text('Show private data'),
                       onPressed: () async {
-                        await Navigator.pushReplacement(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => const ShowKeys()),
-                        );
+                        final loggedIn = await checkLoggedIn();
+
+                        if (loggedIn) {
+                          await Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(
+                                builder: (context) => ShowKeys(
+                                      appName: widget.appName,
+                                      child: Home(appName: widget.appName),
+                                    )),
+                          );
+                        } else {
+                          await Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(
+                                builder: (context) => PopupLogin(
+                                    appName: widget.appName,
+                                    child: Home(appName: widget.appName))),
+                          );
+                        }
                       },
+                    ),
+                    const SizedBox(
+                      height: 10,
                     ),
                   ],
                 ),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,0 +1,137 @@
+/// Home page after user creating account.
+///
+// Time-stamp: <Friday 2024-02-23 08:23:59 +1100 Graham Williams>
+///
+/// Copyright (C) 2024, Software Innovation Institute, ANU.
+///
+/// Licensed under the MIT License (the "License").
+///
+/// License: https://choosealicense.com/licenses/mit/.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+///
+/// Authors: Zheyuan Xu, Anushka Vidanage
+
+library;
+
+import 'package:flutter/material.dart';
+
+import 'package:intl/intl.dart';
+
+import 'package:solidpod/solid.dart';
+
+/// Widget represents the home screen of the application.
+///
+/// It requires [webId] and [authData] to be passed to it during initialization.
+/// These parameters are used for authentication and data retrieval.
+
+class Home extends StatefulWidget {
+  /// Initialise widget variables
+
+  const Home(
+      {
+      //required this.webId,
+      //required this.authData,
+      required this.appName,
+      super.key});
+  //final String webId;
+  final String appName;
+  //final Map<dynamic, dynamic> authData;
+
+  @override
+  HomeState createState() => HomeState();
+}
+
+class HomeState extends State<Home> with SingleTickerProviderStateMixin {
+  String sampleText = '';
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dateStr = DateFormat('dd MMMM yyyy').format(DateTime.now());
+
+    return Scaffold(
+        appBar: AppBar(
+          // backgroundColor: lightGreen,
+          centerTitle: true,
+          title: Text(widget.appName),
+        ),
+        body: SingleChildScrollView(
+          child: Column(
+            children: [
+              const SizedBox(
+                height: 10,
+              ),
+              //const ShowKeys(),
+              Padding(
+                padding: const EdgeInsets.all(10.0),
+                child: Column(
+                  children: [
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Date: $dateStr',
+                          style: const TextStyle(
+                            fontSize: 15,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(
+                      height: 10,
+                    ),
+                    const Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Welcome to your new app!',
+                          style: TextStyle(
+                            fontSize: 22,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(
+                      height: 10,
+                    ),
+                    ElevatedButton(
+                      child: const Text('Show private data'),
+                      onPressed: () async {
+                        await Navigator.pushReplacement(
+                          context,
+                          MaterialPageRoute(
+                              builder: (context) => const ShowKeys()),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ));
+  }
+}

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -33,7 +33,7 @@ library;
 import 'package:flutter/material.dart';
 
 import 'package:intl/intl.dart';
-import 'package:solidpod/solid.dart';
+import 'package:solidpod/solidpod.dart';
 
 import 'package:keypod/screens/view_keys.dart';
 

--- a/lib/screens/view_keys.dart
+++ b/lib/screens/view_keys.dart
@@ -31,7 +31,7 @@
 import 'package:flutter/material.dart';
 import 'package:keypod/screens/home.dart';
 
-import 'package:solidpod/solid.dart';
+import 'package:solidpod/solidpod.dart';
 
 /// A widget to show the user all the encryption keys stored in their POD.
 

--- a/lib/screens/view_keys.dart
+++ b/lib/screens/view_keys.dart
@@ -1,0 +1,169 @@
+/// A widget to view private data in a POD.
+///
+// Time-stamp: <Monday 2024-03-04 15:45:47 +1100 Graham Williams>
+///
+/// Copyright (C) 2024, Software Innovation Institute, ANU.
+///
+/// Licensed under the MIT License (the "License").
+///
+/// License: https://choosealicense.com/licenses/mit/.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+///
+/// Authors: Anushka Vidanage
+
+import 'package:flutter/material.dart';
+import 'package:keypod/screens/home.dart';
+
+import 'package:solidpod/solid.dart';
+
+/// A widget to show the user all the encryption keys stored in their POD.
+
+class ViewKeys extends StatefulWidget {
+  /// Constructor for ShowKeys widget
+
+  const ViewKeys({
+    required this.appName,
+    required this.keyInfo,
+    super.key,
+  });
+
+  /// Name of the app
+  final String appName;
+
+  /// Data of the key file
+  final String keyInfo;
+
+  @override
+  State<ViewKeys> createState() => _ViewKeysState();
+}
+
+class _ViewKeysState extends State<ViewKeys> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        key: _scaffoldKey,
+        appBar: AppBar(
+          centerTitle: true,
+          title: Text(widget.appName),
+        ),
+        body: loadedScreen(widget.keyInfo));
+  }
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  Widget loadedScreen(String keyData) {
+    final encFileData = getFileContent(keyData);
+
+    //TODO av-20240319: Need to get the encryption key
+    // to decrypt the private key value
+
+    // encKey = secureStorage.read(key: 'key')
+
+    // final keyMaster = Key.fromUtf8(encKey);
+    // final ivInd = IV.fromBase64(encFileData['iv'][1] as String);
+    // final encrypterKey =
+    //     Encrypter(AES(keyMaster, mode: AESMode.cbc));
+
+    // final eccKey = Encrypted.from64(medFileKey);
+    // final keyIndPlain = encrypterKey.decrypt(eccKey, iv: ivInd);
+
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            DataTable(columnSpacing: 30.0, columns: const [
+              DataColumn(
+                label: Text(
+                  'Parameter',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              DataColumn(
+                label: Text(
+                  'Value',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ], rows: [
+              DataRow(cells: [
+                const DataCell(Text(
+                  'Encryption key verification',
+                  style: TextStyle(
+                    fontSize: 12,
+                  ),
+                )),
+                DataCell(Text(
+                  encFileData['encKey'][1] as String,
+                  style: const TextStyle(
+                    fontSize: 12,
+                  ),
+                )),
+              ]),
+              DataRow(cells: [
+                const DataCell(Text(
+                  'Private key',
+                  style: TextStyle(
+                    fontSize: 12,
+                  ),
+                )),
+                DataCell(SizedBox(
+                  width: 600,
+                  child: Text(
+                    encFileData['prvKey'][1] as String,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 12,
+                    ),
+                  ),
+                )),
+              ])
+            ]),
+            const SizedBox(
+              height: 50,
+            ),
+            ElevatedButton(
+              child: const Text('Go back'),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => Home(appName: widget.appName)),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,14 +18,14 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_launcher_icons: ^0.13.1
+  intl: ^0.18.0
   solidpod:
-    path: solidpod # Use a local path whilst solidpod is under development.
+    path: .solidpod # Use a local path whilst solidpod is under development.
     ## git:
     ##   url: https://github.com/anusii/solidpod
     ##   ref: dev
   universal_io: ^2.2.2
   window_manager: ^0.3.7
-  intl: ^0.18.0
   # dart_code_metrics: ^4.0.0
 
 # Define launcher icons for all platforms

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter_launcher_icons: ^0.13.1
   intl: ^0.18.0
   solidpod:
-    path: solidpod # Use a local path whilst solidpod is under development.
+    path: ../solidpod # Use a local path whilst solidpod is under development.
     ## git:
     ##   url: https://github.com/anusii/solidpod
     ##   ref: dev
@@ -61,9 +61,6 @@ dev_dependencies:
     sdk: flutter
   mockito: ^5.4.4
   ubuntu_lints: ^0.3.0
-
-dependency_overrides:
-  file: ^7.0.0 # Only if necessary
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
     sdk: flutter
   flutter_launcher_icons: ^0.13.1
   solidpod:
-    path: ../solidpod # Use a local path whilst solidpod is under development.
+    path: solidpod # Use a local path whilst solidpod is under development.
     ## git:
     ##   url: https://github.com/anusii/solidpod
     ##   ref: main

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,12 +19,13 @@ dependencies:
     sdk: flutter
   flutter_launcher_icons: ^0.13.1
   solidpod:
-    path: solidpod # Use a local path whilst solidpod is under development.
+    path: ../solidpod # Use a local path whilst solidpod is under development.
     ## git:
     ##   url: https://github.com/anusii/solidpod
     ##   ref: main
   universal_io: ^2.2.2
   window_manager: ^0.3.7
+  intl: ^0.18.0
   
 
 # Define launcher icons for all platforms

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
     path: solidpod # Use a local path whilst solidpod is under development.
     ## git:
     ##   url: https://github.com/anusii/solidpod
-    ##   ref: main
+    ##   ref: dev
   universal_io: ^2.2.2
   window_manager: ^0.3.7
   intl: ^0.18.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter_launcher_icons: ^0.13.1
   intl: ^0.18.0
   solidpod:
-    path: ../solidpod # Use a local path whilst solidpod is under development.
+    path: solidpod # Use a local path whilst solidpod is under development.
     ## git:
     ##   url: https://github.com/anusii/solidpod
     ##   ref: dev

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter_launcher_icons: ^0.13.1
   intl: ^0.18.0
   solidpod:
-    path: .solidpod # Use a local path whilst solidpod is under development.
+    path: solidpod # Use a local path whilst solidpod is under development.
     ## git:
     ##   url: https://github.com/anusii/solidpod
     ##   ref: dev

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,9 @@ dev_dependencies:
   mockito: ^5.4.4
   ubuntu_lints: ^0.3.0
 
+dependency_overrides:
+  file: ^7.0.0 # Use only if necessary
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- An initial GUI for viewing private data

- Link to associated issue: https://github.com/anusii/keypod/issues/28

## Checklist

[Use the check-list below to ensure your branch is ready for PR]

- [x] Changes adhere to the team style and coding guideline
- [x] The one line summary included in CHANGELOG.md
- [x] No confidential information
- [x] No duplicated content
- [x] No lint errors (`make prep` or `flutter analyze lib`
                       python: use pre-commit ruff hook to check on commit)
- [x] No lint check errors related to your changes
- [x] Tested on at least one device
      - [ ] Android
      - [ ] Chrome
      - [ ] iOS
      - [ ] Linux
      - [ ] MacOS
      - [x] Windows
- [ ] Added 2 reviewers

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Bump appropriate version number
- [ ] Merge PR into dev
