### PR TITLE
Override the version of intl for solid-auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ the top rather than the bottom.
 
 # 0.4
 
++ Override the version of intl for solid-auth.
 + Add an About dialog [0.3.4]
 + Added popupLogin into the continue placeholder page. 
 + Package solid renamed to solidpod.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ dev_dependencies:
 
 dependency_overrides:
   file: ^7.0.0 # Use only if necessary
+  intl: ^0.19.0  # solid-auth depends on intl-0.19.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: keypod
 description: "Secure POD storage of key-value-note triplets."
 publish_to: "none"
-version: 0.3.4+7
+version: 0.3.4+8
 
 environment:
   sdk: ">=3.2.3 <4.0.0"


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Add dependency override for package `intl`

- Link to associated issue: #56 

## Checklist

[Use the check-list below to ensure your branch is ready for PR]

- [x] Changes adhere to the team style and coding guideline
- [x] The one line summary included in CHANGELOG.md
- [x] No confidential information
- [x] No duplicated content
- [x] No lint errors (`make prep` or `flutter analyze lib`
                       python: use pre-commit ruff hook to check on commit)
- [x] No lint check errors related to your changes
- [x] Tested on at least one device
     - [ ] Android
     - [x] Chrome
     - [ ] iOS
     - [x] Linux
     - [ ] MacOS
     - [ ] Windows
- [x] Added 2 reviewers

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [x] Merge dev into the branch
- [x] Resolve any conflicts
- [x] Bump appropriate version number
- [ ] Merge PR into dev
