### PR TITLE
dc/72 show data right after initialising POD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Here we note high level changes for the Key Pod app.
 Please add the updates beyond 0.3.0 under the 0.4 heading, adding to
 the top rather than the bottom.
 
+# 0.4.8
+
+Fix bug that prevents one from showing data right after initialising POD.
+
 # 0.4.7
 
 Remove hard-coded app name by getting the name from solidpod.

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -94,7 +94,8 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
         const Home(),
       );
 
-      await Navigator.pushReplacement(
+      //await Navigator.pushReplacement( // this won't show the file content if POD initialisation has just been performed
+      await Navigator.push(
         context,
         MaterialPageRoute(
           builder: (context) => ViewKeys(
@@ -102,6 +103,8 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
           ),
         ),
       );
+    } on Exception catch (e) {
+      print('Exception: $e');
     } finally {
       if (mounted) {
         setState(() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: keypod
 description: "Secure POD storage of key-value-note triplets."
 publish_to: "none"
-version: 0.4.7
+version: 0.4.8
 
 environment:
   sdk: ">=3.2.3 <4.0.0"


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Show file content as desired after initialising POD

- Link to associated issue: #72

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [ ] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [x] Linux
  - [ ] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev
