### PR TITLE
Kev/84_redesign

### DIFF
--- a/lib/screens/data_table.dart
+++ b/lib/screens/data_table.dart
@@ -32,6 +32,7 @@ import 'package:solidpod/solidpod.dart';
 import 'package:keypod/screens/about_dialog.dart';
 import 'package:keypod/utils/constants.dart';
 import 'package:keypod/utils/rdf.dart';
+import 'package:keypod/screens/test_home.dart';
 
 class KeyValueTable extends StatefulWidget {
   final String title;
@@ -263,7 +264,12 @@ class _KeyValueTableState extends State<KeyValueTable> {
           ),
           const SizedBox(width: 10),
           ElevatedButton(
-            onPressed: () => _maybeGoBack(context),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const TestHome()),
+              );
+            },
             style: activeButtonStyle(context),
             child: const Text('Testing',
                 style: TextStyle(fontWeight: FontWeight.bold)),

--- a/lib/screens/data_table.dart
+++ b/lib/screens/data_table.dart
@@ -35,18 +35,17 @@ import 'package:keypod/utils/rdf.dart';
 import 'package:keypod/screens/test_home.dart';
 
 class KeyValueTable extends StatefulWidget {
+  const KeyValueTable({
+    required this.title,
+    required this.fileName,
+    required this.child,
+    super.key,
+    this.keyValuePairs,
+  });
   final String title;
   final String fileName;
   final Widget child;
   final List<Map<String, dynamic>>? keyValuePairs;
-
-  const KeyValueTable({
-    Key? key,
-    required this.title,
-    required this.fileName,
-    required this.child,
-    this.keyValuePairs,
-  }) : super(key: key);
 
   @override
   State<KeyValueTable> createState() => _KeyValueTableState();
@@ -71,10 +70,11 @@ class _KeyValueTableState extends State<KeyValueTable> {
   void initState() {
     super.initState();
     if (widget.keyValuePairs != null) {
-      int i = 0;
-      for (var pair in widget.keyValuePairs!) {
-        var keyController = TextEditingController(text: pair[keyStr] as String);
-        var valueController =
+      var i = 0;
+      for (final pair in widget.keyValuePairs!) {
+        final keyController =
+            TextEditingController(text: pair[keyStr] as String);
+        final valueController =
             TextEditingController(text: pair[valStr] as String);
         keyControllers[i] = keyController;
         valueControllers[i] = valueController;
@@ -327,7 +327,7 @@ class _KeyValueTableState extends State<KeyValueTable> {
   ButtonStyle activeButtonStyle(BuildContext context) {
     return ButtonStyle(
       backgroundColor: MaterialStateProperty.resolveWith<Color>(
-        (Set<MaterialState> states) {
+        (states) {
           if (states.contains(MaterialState.disabled)) {
             // Light grey color when disabled.
 
@@ -340,7 +340,7 @@ class _KeyValueTableState extends State<KeyValueTable> {
         },
       ),
       foregroundColor: MaterialStateProperty.resolveWith<Color>(
-        (Set<MaterialState> states) {
+        (states) {
           if (states.contains(MaterialState.disabled)) {
             // Text color when disabled.
 
@@ -369,7 +369,6 @@ class _KeyValueTableState extends State<KeyValueTable> {
 
   Widget _actionCell(int index) {
     return Row(
-      mainAxisAlignment: MainAxisAlignment.start,
       children: [
         IconButton(
           icon: const Icon(Icons.delete, color: Colors.red),

--- a/lib/screens/edit_keyvalue.dart
+++ b/lib/screens/edit_keyvalue.dart
@@ -185,7 +185,7 @@ class _KeyValueEditState extends State<KeyValueEdit> {
           ' to "${widget.fileName}" in PODs');
       return true;
     } on Exception catch (e) {
-      print('Exception: $e');
+      debugPrint('Exception: $e');
     } finally {
       if (mounted) {
         setState(() {

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -148,7 +148,7 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
       );
     } on Exception catch (e) {
-      print('Error: $e');
+      debugPrint('Error: $e');
     } finally {
       if (mounted) {
         setState(() {

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -22,7 +22,6 @@
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
 /// Authors: Kevin Wang
-
 library;
 
 import 'package:flutter/material.dart';
@@ -37,7 +36,7 @@ import 'package:keypod/utils/constants.dart';
 import 'package:keypod/utils/rdf.dart';
 
 class HomeScreen extends StatefulWidget {
-  ///Constructor
+  /// Constructor
   const HomeScreen({super.key});
 
   @override
@@ -46,6 +45,15 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    // Automatically click the KEYPODS button when the screen loads.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _writePrivateData();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -89,7 +97,6 @@ class _HomeScreenState extends State<HomeScreen> {
           ],
         ),
         // Pushes the about button to the bottom.
-
         Expanded(child: Container()),
         Container(
           padding: const EdgeInsets.all(20),
@@ -123,35 +130,34 @@ class _HomeScreenState extends State<HomeScreen> {
     try {
       setState(() {
         // Show loading indicator.
-
         _isLoading = true;
       });
 
       // Simulating a network call.
-
       await Future.delayed(const Duration(seconds: 2));
 
       // Navigate or perform additional actions after loading
-
       final dataDirPath = await getDataDirPath();
       final filePath = path.join(dataDirPath, fileName);
 
       final fileContent = await readPod(filePath, context, const TestHome());
       final pairs = fileContent == null ? null : await parseTTLStr(fileContent);
       // Convert each tuple to a Map.
-
       final keyValuePairs = pairs?.map((pair) {
         return {'key': pair.key, 'value': pair.value};
       }).toList();
 
       await Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(
-              builder: (context) => KeyValueTable(
-                  title: 'Key Value Pair Editor',
-                  fileName: fileName,
-                  keyValuePairs: keyValuePairs,
-                  child: const HomeScreen())));
+        context,
+        MaterialPageRoute(
+          builder: (context) => KeyValueTable(
+            title: 'Key Value Pair Editor',
+            fileName: fileName,
+            keyValuePairs: keyValuePairs,
+            child: const HomeScreen(),
+          ),
+        ),
+      );
     } on Exception catch (e) {
       print('Error: $e');
     } finally {

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -59,7 +59,7 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Loading Key Value Pairs...'),
+        title: const Text('Loading Key Value Pairs... '),
         backgroundColor: titleBackgroundColor,
         automaticallyImplyLeading: false,
       ),

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -59,7 +59,7 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Home Screen'),
+        title: const Text('Loading Key Value Pairs...'),
         backgroundColor: titleBackgroundColor,
         automaticallyImplyLeading: false,
       ),
@@ -84,18 +84,7 @@ class _HomeScreenState extends State<HomeScreen> {
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
         const SizedBox(height: 20),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: <Widget>[
-            _buildButton('KEYPODS', _writePrivateData),
-            _buildButton('TESTING', () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => const TestHome()),
-              );
-            }),
-          ],
-        ),
+
         // Pushes the about button to the bottom.
         Expanded(child: Container()),
         Container(

--- a/lib/screens/test_home.dart
+++ b/lib/screens/test_home.dart
@@ -181,7 +181,7 @@ class TestHomeState extends State<TestHome>
               color: Colors.purple,
             ),
             onPressed: () async {
-              aboutDialog(context);
+              await aboutDialog(context);
             },
             tooltip: 'Popup a window about the app.',
           ),


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- KeyValue Table becomes the first page (home) of the app. Replace Home button with Testing to go to the testing page.

- Link to associated issue: #84 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [ ] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [x] Chrome
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
- [ ] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev
