### PR TITLE
dc/149 redirect after init POD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ numbers.
 
 ## 0.6 FUTURE
 
++ Fix: not redirecting appropriately after initialising POD [0.5.1]
+
 ## 0.5 20240522
 
 + Update license to GPL. [0.4.14]

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -123,7 +123,7 @@ class _HomeScreenState extends State<HomeScreen> {
         return {'key': pair.key, 'value': pair.value};
       }).toList();
 
-      await Navigator.pushReplacement(
+      await Navigator.push(
         context,
         MaterialPageRoute(
           builder: (context) => KeyValueTable(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: keypod
 description: "Secure POD storage of key-value-note triplets."
 publish_to: "none"
-version: 0.5.0+1
+version: 0.5.1+1
 
 environment:
   sdk: ">=3.2.3 <4.0.0"


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- This is a temporary fix to redirect to the home page after initialising POD, a better fix is required by resolving https://github.com/anusii/solidpod/issues/157
- Link to associated issue: https://github.com/anusii/solidpod/issues/149

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [x] Linux
  - [ ] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [x] Merge dev into the branch
- [x] Resolve any conflicts
- [x] Add one line summary into CHANGELOG.md
- [x] Bump appropriate version number in pubspec.yaml
- [x] Push to git repository and review
- [x] Merge PR into dev
