### PR TITLE
dc/160 nonencrypt demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ numbers.
 
 ## 0.6 FUTURE
 
++ Demonstrate the read/write of non-encrypted data file [0.5.2]
 + Fix: not redirecting appropriately after initialising POD [0.5.1]
 
 ## 0.5 20240522

--- a/lib/screens/demo.dart
+++ b/lib/screens/demo.dart
@@ -30,6 +30,8 @@
 
 library;
 
+import 'dart:ffi';
+
 import 'package:flutter/material.dart';
 
 import 'package:intl/intl.dart';
@@ -73,6 +75,9 @@ class DemoScreenState extends State<DemoScreen>
   // Step 1: Loading state variable.
 
   bool _isLoading = false;
+
+  // Indicator for write encrypted/plaintext data
+  bool _writeEncrypted = false;
 
   @override
   void initState() {
@@ -130,7 +135,7 @@ class DemoScreenState extends State<DemoScreen>
     // final fileName = 'test-101.ttl';
     // final fileContent = 'This is for testing writePod.';
 
-    const fileName = dataFile;
+    final fileName = _writeEncrypted ? dataFile : dataFilePlain;
 
     try {
       final dataDirPath = await getDataDirPath();
@@ -146,6 +151,7 @@ class DemoScreenState extends State<DemoScreen>
                   title: 'Basic Key Value Editor',
                   fileName: fileName,
                   keyValuePairs: pairs,
+                  encrypted: _writeEncrypted,
                   child: const DemoScreen())));
     } on Exception catch (e) {
       debugPrint('Exception: $e');
@@ -170,6 +176,10 @@ class DemoScreenState extends State<DemoScreen>
 
     const smallGapV = SizedBox(height: 10.0);
     const largeGapV = SizedBox(height: 40.0);
+
+    // A small horizontal spacing for the widget.
+
+    const smallGapH = SizedBox(width: 10.0);
 
     // Some handy widgets that will be displyed. These are defined here to
     // reduce the complexity of the code below.
@@ -266,6 +276,27 @@ class DemoScreenState extends State<DemoScreen>
                             await _writePrivateData();
                           },
                         ),
+                        Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              smallGapH,
+                              const Text(
+                                'Encrypt Data?',
+                                style: TextStyle(fontWeight: FontWeight.bold),
+                              ),
+                              smallGapH,
+                              Switch(
+                                value: _writeEncrypted,
+                                onChanged: (val) {
+                                  setState(() {
+                                    _writeEncrypted = val;
+                                    debugPrint(
+                                        '_writeEncrypted = $_writeEncrypted');
+                                  });
+                                },
+                              )
+                            ]),
+
                         largeGapV,
                         const Row(
                           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screens/edit_keyvalue.dart
+++ b/lib/screens/edit_keyvalue.dart
@@ -40,12 +40,14 @@ class KeyValueEdit extends StatefulWidget {
       {required this.title,
       required this.fileName,
       required this.child,
+      this.encrypted = true,
       this.keyValuePairs,
       super.key});
 
   final String title;
   final String fileName; // file to be saved in PODs
   final Widget child;
+  final bool encrypted;
   final List<({String key, dynamic value})>?
       keyValuePairs; // initial key value pairs
 
@@ -179,7 +181,8 @@ class _KeyValueEditState extends State<KeyValueEdit> {
       final ttlStr = await genTTLStr(pairs!);
 
       // Write to POD
-      await writePod(widget.fileName, ttlStr, context, widget.child);
+      await writePod(widget.fileName, ttlStr, context, widget.child,
+          encrypted: widget.encrypted);
 
       await _alert('Successfully saved ${dataMap.length} key-value pairs'
           ' to "${widget.fileName}" in PODs');

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -30,3 +30,5 @@ import 'package:flutter/material.dart';
 const titleBackgroundColor = Color(0xFFF0E4D7);
 
 const dataFile = 'key-value.ttl';
+
+const dataFilePlain = 'key-value-plain.ttl';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: keypod
 description: "Secure POD storage of key-value-note triplets."
 publish_to: "none"
-version: 0.5.1+1
+version: 0.5.2+1
 
 environment:
   sdk: ">=3.2.3 <4.0.0"


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- A demo to show the support of non-encrypted content in readPod() and writePod() implemented in pull request https://github.com/anusii/solidpod/pull/161

- Link to associated issue: https://github.com/anusii/solidpod/issues/160

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [ ] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [x] Linux
  - [ ] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [x] Merge dev into the branch
- [x] Resolve any conflicts
- [x] Add one line summary into CHANGELOG.md
- [x] Bump appropriate version number in pubspec.yaml
- [x] Push to git repository and review
- [x] Merge PR into dev
